### PR TITLE
Updates for Rails 7

### DIFF
--- a/lib/schema2plantuml.rb
+++ b/lib/schema2plantuml.rb
@@ -1,5 +1,5 @@
 require "schema2plantuml/version"
-require "Schema2plantuml/active_record/schema"
+require "schema2plantuml/active_record/schema"
 
 class Schema2plantuml
   def initialize(schema_file_path = 'schema.rb')

--- a/lib/schema2plantuml/active_record/schema.rb
+++ b/lib/schema2plantuml/active_record/schema.rb
@@ -21,6 +21,10 @@ module ActiveRecord
     def enable_extension(*); end
     def add_index(*); end
     def create_view(*); end
+
+    def self.[](_version)
+      self
+    end
   end
 
   class Table2plantuml


### PR DESCRIPTION
This update allows for parsing the Rails 7 schema.rb format that includes the rails version e.g. `ActiveRecord::Schema[7.1].define(...)`